### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-using-docker.yml
+++ b/.github/workflows/build-using-docker.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test-in-docker:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Potential fix for [https://github.com/hprs-in/PSLabel/security/code-scanning/1](https://github.com/hprs-in/PSLabel/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will explicitly define the permissions required for the workflow, limiting the `GITHUB_TOKEN` to the least privileges necessary. Based on the workflow's steps, the minimal permissions required are likely `contents: read` for checking out the repository and `contents: write` for uploading artifacts. If no write permissions are needed, the block can be set to `contents: read` only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
