### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/hprs-in/PSLabel/security/code-scanning/2](https://github.com/hprs-in/PSLabel/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the `build` job in the workflow file. The permissions should be set to `contents: read`, which is the minimal privilege required for the job to function correctly. This ensures that the GITHUB_TOKEN is restricted to read-only access to repository contents, adhering to the principle of least privilege.

The changes will be made in the `.github/workflows/docs.yml` file, specifically within the `build` job definition. No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
