### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: Build code
 
+permissions:
+  contents: read
+  actions: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/hprs-in/PSLabel/security/code-scanning/4](https://github.com/hprs-in/PSLabel/security/code-scanning/4)

To fix the issue, an explicit `permissions` block must be added to the workflow. This block should grant only the minimal permissions required for the workflow to function correctly. In this case:

1. The workflow performs operations such as checking out the repository, which requires `contents: read`.
2. It uploads artifacts, which requires `actions: write`.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or specifically to the `build` job. Adding it at the root level provides clarity and ensures all jobs in this workflow inherit the same permissions unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
