### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,8 @@ jobs:
 
   build-binaries:
     needs: stage-release
+    permissions:
+      contents: read
     uses: ./.github/workflows/build.yml
 
   upload-binaries:


### PR DESCRIPTION
Potential fix for [https://github.com/hprs-in/PSLabel/security/code-scanning/5](https://github.com/hprs-in/PSLabel/security/code-scanning/5)

To fix the issue, we will explicitly define permissions for the `build-binaries` job within this workflow file. This will ensure it adheres to the principle of least privilege, even if the referenced file lacks proper permissions settings. 

- The `permissions` key will be added to the `build-binaries` job. Since the job likely performs read-only operations, we can set its permissions to `contents: read`.
- This change is restricted to the `.github/workflows/release.yml` file and does not alter functionality, as it only limits unnecessary privileges.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
