### PR TITLE
Clean up release workflow settings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,5 @@
 name: Create Release
 
-  
 on:
   push:
     tags:


### PR DESCRIPTION
Remove concurrency settings and unnecessary whitespace from the release workflow for improved clarity and simplicity.